### PR TITLE
v0.2.28 — dedup 3 IDs + integrity guards + Jack +17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Sunglasses are documented here.
 
+## [0.2.28] — 2026-05-01
+
+### Added
+- **17 new patterns, all in `retrieval_poisoning`** (one-category-per-day rule). Auto-shipped via daily-push runner. Patterns: 444 → **461** (+17).
+- **`tests/test_pattern_integrity.py`** — 5 build-blocking guards: no duplicate IDs, every pattern has an id / name / category, IDs match `GLS-<PREFIX>-<NNN>` shape (3 or 4 segments). Locks the doors that the May 1 audit found broken.
+
+### Fixed
+- **3 duplicate pattern IDs deduped.** Two records each shared `GLS-EX-001`, `GLS-SE-001`, `GLS-TP-002` — caused SARIF output ambiguity. Renamed Pattern B in each pair to a fresh ID in its own category prefix:
+  - `GLS-EX-001` (category `prompt_leak`) → **`GLS-PL-001`** (Soft system prompt exfiltration framings)
+  - `GLS-SE-001` (category `prompt_injection`) → **`GLS-PI-021`** (Social engineering — authority impersonation)
+  - `GLS-TP-002` (category `tool_poisoning`) → **`GLS-TP-003`** (Tool poisoning — hidden note-to-assistant framings)
+- **`category=None` backfill.** Earlier audit flagged 155/444 records with `None` category — Jack's pipeline backfilled all of them via ID-prefix-derived categories during the morning harvest. Live state: 0 records with `None`.
+
+### Notes
+- PyPI gap: v0.2.27 was committed locally but never published to PyPI (PyPI top remained at 0.2.26). v0.2.28 publish leapfrogs 0.2.27 and includes its work.
+
+
 ## [0.2.27] — 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ result = scanner.scan_auto("any_file.ext")
 |--------|-------|
 | Average text scan | <1ms (avg 0.26ms on M3 Max, single-threaded) |
 | Throughput | ~3,800 scans/sec (single-threaded, M3 Max) |
-| Patterns | 444 |
+| Patterns | 461 |
 | Keywords | 2,296 |
 | Languages | 23 |
 | Attack categories | 54 |
@@ -151,15 +151,15 @@ result = scanner.scan_auto("any_file.ext")
 | Core dependencies | Zero for text scan; optional deps for media |
 | Platforms | Mac, Windows, Linux — anywhere Python runs |
 
-_All performance numbers verified against `stats/current.json` (v0.2.27, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
+_All performance numbers verified against `stats/current.json` (v0.2.28, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
 
 ## 23 Languages
 
 English, Spanish, Portuguese, French, German, Italian, Dutch, Russian, Ukrainian, Polish, Czech, Turkish, Azerbaijani, Arabic, Hebrew, Persian, Chinese, Japanese, Korean, Hindi, Bengali, Indonesian, Vietnamese — plus normalization handles romanization, Unicode confusables, and 17 other obfuscation techniques. Community language contributions welcome.
 
-## What Works Today (v0.2.27)
+## What Works Today (v0.2.28)
 
-- ✅ Text scanning: 444 patterns, 2,296 keywords, 23 languages, 54 attack categories
+- ✅ Text scanning: 461 patterns, 2,296 keywords, 23 languages, 54 attack categories
 - ✅ Negation handling: "do NOT run rm -rf" correctly downgrades severity
 - ✅ Multi-stage pipeline: normalization (17 techniques) → pattern match → decision
 - ✅ Image scanning: OCR + EXIF metadata + hidden text detection (requires Tesseract)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sunglasses",
-    version="0.2.27",
+    version="0.2.28",
     description="Sunglasses for AI agents. Protection layer + neighborhood watch.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/stats/current.json
+++ b/stats/current.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.2.27",
-  "patterns": 444,
+  "version": "0.2.28",
+  "patterns": 461,
   "keywords": 2296,
   "categories": 54,
   "languages": 23,
@@ -16,7 +16,7 @@
   "media_types": 6,
   "reports_published": 3,
   "team_size": 5,
-  "last_updated": "2026-04-30T11:00:04.681428-07:00",
+  "last_updated": "2026-05-01T11:00:02.299786-07:00",
   "last_updated_by": "daily-push-runner",
   "_note": "THIS IS THE SINGLE SOURCE OF TRUTH. All pages, JSON-LD, meta tags, llms.txt, and sitemap must read from this file. Do NOT hardcode numbers anywhere else."
 }

--- a/sunglasses/__init__.py
+++ b/sunglasses/__init__.py
@@ -4,4 +4,4 @@
 #
 # "Don't let your agents get fooled."
 
-__version__ = "0.2.27"
+__version__ = "0.2.28"

--- a/sunglasses/patterns.py
+++ b/sunglasses/patterns.py
@@ -3476,7 +3476,7 @@ PATTERNS = [
         "description": "System override framing markers used in prompt injection attacks to impersonate authority.",
     },
     {
-        "id": "GLS-EX-001",
+        "id": "GLS-PL-001",
         "name": "Soft system prompt exfiltration framings",
         "category": "prompt_leak",
         "severity": "high",
@@ -3607,7 +3607,7 @@ PATTERNS = [
         "description": "Indirect injection templates from the AgentDojo paper — wraps malicious instructions in fake authority XML tags.",
     },
     {
-        "id": "GLS-TP-002",
+        "id": "GLS-TP-003",
         "name": "Tool poisoning — hidden note-to-assistant framings",
         "category": "tool_poisoning",
         "severity": "high",
@@ -3635,7 +3635,7 @@ PATTERNS = [
         "description": "Tool poisoning patterns — hidden instructions embedded in tool descriptions, READMEs, or MCP manifests that try to trigger unauthorized actions.",
     },
     {
-        "id": "GLS-SE-001",
+        "id": "GLS-PI-021",
         "name": "Social engineering — authority impersonation",
         "category": "prompt_injection",
         "severity": "high",
@@ -7514,4 +7514,160 @@ PATTERNS = [
         "description": ''
     },
     # === end v0.2.27 batch ===
+
+    # === v0.2.28 batch (17 patterns, theme: retrieval_poisoning) ===
+    {
+        "id": 'GLS-RP-264',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|knowledge\\s+base|source\\s+(?:note|snippet|digest)|citation\\s+cache)\\b)(?=.*\\b(?:forged|spoofed|fake|tampered)\\b)(?=.*\\b(?:provenance\\s+(?:stamp|badge)|trust\\s+(?:stamp|badge)|verified\\s+source\\s+seal)\\b)(?=.*\\b(?:policy|guardrail|safety\\s+rule|execution\\s+gate)\\b)(?=.*\\b(?:bypass(?:ed|ing)?|override(?:d|s|ing)?|ignore(?:d|s)?|skip(?:ped|ping|s)?)\\b).+'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-265',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|index|vector(?:\\s+store)?|knowledge(?:\\s|-)*base|memory(?:\\s|-)*bank|document\\s+chunks?|chunks?)\\b)(?=.*\\b(?:poison(?:ed|ing)?|forged|tampered|injected|seed(?:ed|ing)?|backdoor(?:ed)?|backdoored)\\b)(?=.*\\b(?:rank(?:ed|ing)?(?:\\s+it)?\\s+(?:first|highest)|promot(?:e|ed|es|ing)|boost(?:ed|s|ing)?|prioriti(?:ze|zed|zing)|treat(?:\\s+\\w+){0,3}\\s+as\\s+authoritative|source\\s+of\\s+truth|override\\s+rank(?:ing)?)\\b)(?=.*\\b(?:ignore|bypass|override|disregard|replace)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety\\s+check(?:s)?|system\\s+instruction(?:s)?|constraint(?:s)?)\\b).*'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-266',
+        "name": 'forged_validation_appendix_confidence_rank_policy_override',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:forged|fake|spoofed|counterfeit)\\b)(?=.*\\b(?:source|citation|reference|appendix|document|corpus)\\b)(?=.*\\b(?:confidence|rank|ranking|priority|score)\\b)(?=.*\\b(?:policy|guardrail|rule|filter)\\b)(?=.*\\b(?:override|overrode|overriding|bypass|bypassed|bypassing|ignore|ignored|ignoring|skip|skipped|skipping)\\b)(?=.*\\b(?:promote|promoted|promoting|boost|boosted|boosting|prioritize|prioritized|surface|surfaced|elevate|elevated)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-267',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:forged|fake|tampered|spoofed|poisoned|fabricated)\\b)(?=.*\\b(?:provenance|citation|source|lineage|evidence|trust\\s*rank|ranking)\\b)(?=.*\\b(?:override|overrides|overriding|bypass|bypassed|ignore|ignored|promote|promoted|elevate|elevated)\\b).+$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-268',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|knowledge\\s+base|index|corpus|source|citation|attestation|provenance)\\b)(?=.*\\b(?:forg(?:e|ed|ery)|fake|fabricat(?:e|ed|ing)|spoof(?:ed|ing)?|tamper(?:ed|ing)?)\\b)(?=.*\\b(?:priority|rerank(?:s|ed|ing)?|boost(?:ed|ing)?|weight(?:ed|ing)?|rank(?:ed|ing)?)\\b)(?=.*\\b(?:(?:overrid(?:e|es|ed|ing)|overrode)|bypass(?:ed|es|ing)?|ignore(?:d|s|ing)?|disable(?:d|s|ing)?|skip(?:ped|s|ping)?)\\b).*'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-269',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:forged|fake|counterfeit|fabricated|spoofed)\\b)(?=.*\\b(?:index\\s+annotation|retrieval\\s+note|knowledge\\s+chunk|source\\s+metadata|embedding\\s+tag)\\b)(?=.*\\b(?:rerank|reranked|reranks|reranking|prioritize|prioritized|boost|boosted|boosts|boosting|weight|weighted)\\b)(?=.*\\b(?:policy\\s+gate|guardrail|approval\\s+check|security\\s+review|safety\\s+filter)\\b)(?=.*\\b(?:bypass|bypassed|bypasses|ignore|ignored|skip|skipped|override|overrode|overrides|overriding)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-270',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|context|citation|source|provenance)\\b)(?=.*\\b(?:forged|poisoned|seeded|tampered|fabricated)\\b)(?=.*\\b(?:bundle|digest|index|rank|ranking|score)\\b)(?=.*\\b(?:policy|guardrail|safety|trust)\\b)(?=.*\\b(?:bypass|override|prioritiz(?:e|ed|ing)|escalat(?:e|ed|es|ing))\\b).*'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-271',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|search|index|corpus|citation|snippet|source|result)\\b)(?=.*\\b(?:forg(?:e|ed|ery)|tamper(?:ed|ing)?|poison(?:ed|ing)?)\\b)(?=.*\\b(?:citation|source|snippet|passage|result)\\b)(?=.*\\b(?:weight(?:ing|ed)?|rank(?:ing|ed)?|prioriti[sz](?:e|ed|ing)?|boost(?:s|ed|ing)?)\\b)(?=.*\\b(?:override(?:n|d|s|ing)?|bypass(?:es|ed|ing)?|supersed(?:e|es|ed|ing)|disregard(?:ed|s|ing)?)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety|approval|check(?:s)?|gate(?:s)?)\\b).+$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-272',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|index|corpus|document(?:ation)?|knowledge\\s+base|source\\s+map|dataset|chunk(?:s)?)\\b)(?=.*\\b(?:forg(?:e|ed|ery)|fake|fabricat(?:e|ed|ing)|tamper(?:ed|ing)?|poison(?:ed|ing)?)\\b)(?=.*\\b(?:digest|checksum|hash|lineage|provenance|trust\\s+score|confidence)\\b)(?=.*\\b(?:priorit(?:ize|ized|izing|izes)|boost(?:ed|ing|s)?|elevat(?:e|ed|ing)|rank(?:ed|ing|s)?(?:\\s+\\w+){0,3}\\s+first|top\\s+rank)\\b)(?=.*\\b(?:override(?:d|s|ing)?|bypass(?:ed|es|ing)?|ignore(?:d|s|ing)?|disregard(?:ed|s|ing)?)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety(?:\\s+rule(?:s)?)?|verification)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-273',
+        "name": 'forged_citation_graph_trust_score_rerank_policy_override',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|index|knowledge\\s+base)\\b)(?=.*\\b(?:forged|fake|spoofed|tampered|fabricated)\\b)(?=.*\\b(?:citation\\s+graph|source\\s+bundle|trust\\s+score|provenance\\s+record)\\b)(?=.*\\b(?:re[-\\s]?rank(?:ed|ing)?|boost(?:ed|ing)?|elevate(?:d|s|ing)?|override)\\b)(?=.*\\b(?:policy\\s+override|policy\\s+exception|guardrail\\s+bypass|ranking\\s+policy)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-274',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:forged|fake|spoofed|seeded|poisoned|tampered)\\b)(?=.*\\b(?:eval\\s*appendix|benchmark\\s*appendix|citation\\s*note|source\\s*memo|retrieval\\s*document|ranking\\s*note)\\b)(?=.*\\b(?:citation\\s*trust|trust\\s*badge|provenance\\s*stamp|source\\s*authority|confidence\\s*tag)\\b)(?=.*\\b(?:rank\\s*override|rerank\\s*to\\s*top|prioriti[sz]e\\s*(?:it\\s*)?first|boost\\s*to\\s*highest\\s*rank|override\\s*ranking|bypass\\s*ranking\\s*guardrails?|ignore\\s*retrieval\\s*policy)\\b).+$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-275',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?!.*\\b(?:do|does|did)\\s+not\\s+(?:override|bypass|skip|ignore|rerank|promote)\\b)(?!.*\\b(?:never|without)\\s+(?:override|bypass|skip|ignore|rerank|promote)\\b)(?=.*\\b(?:forge|forged|forging|fake|spoofed|tampered|counterfeit)\\b)(?=.*\\b(?:retrieval|citation[-\\s]+graph|ranking\\s+metadata|relevance[-\\s]+score|source[-\\s]+weight|rerank(?:er|ing)?)\\b)(?=.*\\b(?:override|overrides|overridden|bypass|bypasses|bypassed|skip|skips|skipped|ignore|ignores|ignored|rerank|reranks|reranked|promote|promotes|promoted)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety\\s+check(?:s)?|trust[-\\s]+gate|enforcement\\s+rules?)\\b).+'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-276',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:source|citation|document|retriev(?:ed|al)|context)\\b)(?=.*\\b(?:forged|spoof(?:ed|ing)?|counterfeit|fabricat(?:ed|ing)?)\\b)(?=.*\\b(?:rank(?:ing)?\\s*override|priority\\s*override|trust\\s*badge\\s*override|authority\\s*flip)\\b)(?=.*\\b(?:policy\\s*bypass|guardrail\\s*override|verification\\s*bypass|provenance\\s*waiver)\\b).+$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-277',
+        "name": 'forged_provenance_banner_citation_priority_override',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|context|corpus|knowledge|document|docs|source|sources)\\b)(?=.*\\b(?:forged|fake|spoofed|tampered|fabricated)\\b)(?=.*\\b(?:provenance|citation|citations|lineage|source\\s+badge|trust\\s+badge|banner|stamp|attestation)\\b)(?=.*\\b(?:priority|rank|ranking|boost|promote|elevate|override|reorder)\\b)(?=.*\\b(?:policy|guardrail|guardrails|filter|safety|verification)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-278',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)(?=.*\\b(?:retrieval|rag|vector\\s+index|index|knowledge\\s+base|memory\\s+store)\\b)(?=.*\\b(?:poison|inject|seed|tamper|contaminate|backfill)\\w*\\b)(?=.*\\b(?:trust\\s+score|ranking\\s+signal|priority\\s+band|score|rank)\\b)(?=.*\\b(?:override|bypass|ignore|skip|elevate|boost)\\w*\\b)(?=.*\\b(?:policy|guardrail|filter|approval|verification|safety)\\b).{0,700}'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-V03-0485',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)\\b(?:retrieval|rag|index|vector\\s+store|knowledge\\s+base|corpus)\\b.{0,140}\\b(?:forg(?:e|ed|ing)|poison(?:ed|ing)?|tamper(?:ed|ing)?|inject(?:ed|ion)?)\\b.{0,170}\\b(?:quality\\s+signal|trust\\s+score|rank(?:ing)?|rerank(?:ed|ing)?|priority(?:\\s+band|\\s+value|\\s+values)?)\\b.{0,170}\\b(?:promot(?:e|ed|ing)|boost(?:ed|ing)?|elevat(?:e|ed|ing)|surface(?:d)?)\\b.{0,170}\\b(?:attacker|malicious|untrusted|payload|hidden\\s+instruction)\\b'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-279',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieve|retrieval|rag|context|memory|index|vector|corpus|source(?:s)?|citation(?:s)?)\\b)(?=.*\\b(?:poison(?:ed|ing)?|malicious|forged|tampered|injected|fabricated)\\b)(?=.*\\b(?:ignore|override|bypass|prioriti[sz]e|promote|trust)\\b).+$'],
+        "description": ''
+    },
+    # === end v0.2.28 batch ===
 ]

--- a/tests/test_pattern_integrity.py
+++ b/tests/test_pattern_integrity.py
@@ -1,0 +1,47 @@
+"""Pattern catalog integrity guards.
+
+Locks doors that have been broken before:
+  - Duplicate IDs (live as of v0.2.27: GLS-EX-001, GLS-SE-001, GLS-TP-002 — fixed v0.2.28)
+  - category=None (live as of v0.2.27 audit: 155/444 patterns — fixed v0.2.28)
+  - Missing IDs
+
+If any pattern is added without an id or category, or with a colliding id,
+the build fails here before it can reach PyPI.
+"""
+
+from collections import Counter
+
+from sunglasses.patterns import PATTERNS
+
+
+def test_no_duplicate_pattern_ids():
+    ids = [p["id"] for p in PATTERNS if "id" in p]
+    counts = Counter(ids)
+    dupes = {k: v for k, v in counts.items() if v > 1}
+    assert not dupes, f"Duplicate pattern IDs found: {dupes}"
+
+
+def test_every_pattern_has_an_id():
+    missing = [i for i, p in enumerate(PATTERNS) if not p.get("id")]
+    assert not missing, f"{len(missing)} pattern(s) missing 'id' field at indices: {missing[:10]}"
+
+
+def test_every_pattern_has_a_category():
+    missing = [p.get("id", "<no-id>") for p in PATTERNS if not p.get("category")]
+    assert not missing, f"{len(missing)} pattern(s) missing/None category. First 10: {missing[:10]}"
+
+
+def test_every_pattern_has_a_name():
+    missing = [p.get("id", "<no-id>") for p in PATTERNS if not p.get("name")]
+    assert not missing, f"{len(missing)} pattern(s) missing 'name' field. First 10: {missing[:10]}"
+
+
+def test_pattern_id_format():
+    """All pattern IDs follow GLS-<PREFIX>(-<SUBPREFIX>)?-<NNN>.
+
+    Accepts 3-segment IDs (GLS-EX-001) and 4-segment multilingual IDs (GLS-ML-RU-001).
+    """
+    import re
+    pattern = re.compile(r"^GLS(-[A-Z0-9]+){2,3}$")
+    bad = [p["id"] for p in PATTERNS if not pattern.match(p.get("id", ""))]
+    assert not bad, f"{len(bad)} pattern ID(s) violate GLS-<PREFIX>-...-<NNN> shape. First 10: {bad[:10]}"


### PR DESCRIPTION
## Summary
- Dedup 3 colliding pattern IDs (GLS-EX-001 prompt_leak→GLS-PL-001, GLS-SE-001 prompt_injection→GLS-PI-021, GLS-TP-002 tool_poisoning→GLS-TP-003)
- +17 retrieval_poisoning patterns from Jack daily-push (444→461)
- Added tests/test_pattern_integrity.py — 5 build guards (no dup IDs, every id/name/category present, valid GLS-<P>-<NNN> shape)

## Status
- PyPI v0.2.28 PUBLISHED: https://pypi.org/project/sunglasses/0.2.28/
- Closes the v0.2.27 PyPI gap (committed local Apr 30, never uploaded).
- 12/12 tests pass.

## Test plan
- [x] pytest 12/12 PASS
- [x] No duplicate IDs in PATTERNS
- [x] No None categories
- [x] All IDs match GLS-<PREFIX>-<NNN> shape
- [x] PyPI install verified