### PR TITLE
v0.2.32: 520 patterns, 2,296 keywords, 54 categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Sunglasses are documented here.
 
+## [0.2.32] — 2026-05-04
+
+### Added
+- **13 new patterns, all in `retrieval_poisoning`** (one-category-per-day rule). Auto-shipped via daily-push runner.
+
+
 ## [0.2.31] — 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ result = scanner.scan_auto("any_file.ext")
 |--------|-------|
 | Average text scan | <1ms (avg 0.26ms on M3 Max, single-threaded) |
 | Throughput | ~3,800 scans/sec (single-threaded, M3 Max) |
-| Patterns | 507 |
+| Patterns | 520 |
 | Keywords | 2,296 |
 | Languages | 23 |
 | Attack categories | 54 |
@@ -151,15 +151,15 @@ result = scanner.scan_auto("any_file.ext")
 | Core dependencies | Zero for text scan; optional deps for media |
 | Platforms | Mac, Windows, Linux — anywhere Python runs |
 
-_All performance numbers verified against `stats/current.json` (v0.2.31, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
+_All performance numbers verified against `stats/current.json` (v0.2.32, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
 
 ## 23 Languages
 
 English, Spanish, Portuguese, French, German, Italian, Dutch, Russian, Ukrainian, Polish, Czech, Turkish, Azerbaijani, Arabic, Hebrew, Persian, Chinese, Japanese, Korean, Hindi, Bengali, Indonesian, Vietnamese — plus normalization handles romanization, Unicode confusables, and 17 other obfuscation techniques. Community language contributions welcome.
 
-## What Works Today (v0.2.31)
+## What Works Today (v0.2.32)
 
-- ✅ Text scanning: 507 patterns, 2,296 keywords, 23 languages, 54 attack categories
+- ✅ Text scanning: 520 patterns, 2,296 keywords, 23 languages, 54 attack categories
 - ✅ Negation handling: "do NOT run rm -rf" correctly downgrades severity
 - ✅ Multi-stage pipeline: normalization (17 techniques) → pattern match → decision
 - ✅ Image scanning: OCR + EXIF metadata + hidden text detection (requires Tesseract)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sunglasses",
-    version="0.2.31",
+    version="0.2.32",
     description="Sunglasses for AI agents. Protection layer + neighborhood watch.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/stats/current.json
+++ b/stats/current.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.2.31",
-  "patterns": 507,
+  "version": "0.2.32",
+  "patterns": 520,
   "keywords": 2296,
   "categories": 54,
   "languages": 23,
@@ -16,7 +16,7 @@
   "media_types": 6,
   "reports_published": 3,
   "team_size": 5,
-  "last_updated": "2026-05-03T11:00:02.322351-07:00",
+  "last_updated": "2026-05-04T11:00:02.280044-07:00",
   "last_updated_by": "daily-push-runner",
   "_note": "THIS IS THE SINGLE SOURCE OF TRUTH. All pages, JSON-LD, meta tags, llms.txt, and sitemap must read from this file. Do NOT hardcode numbers anywhere else."
 }

--- a/sunglasses/__init__.py
+++ b/sunglasses/__init__.py
@@ -4,4 +4,4 @@
 #
 # "Don't let your agents get fooled."
 
-__version__ = "0.2.31"
+__version__ = "0.2.32"

--- a/sunglasses/patterns.py
+++ b/sunglasses/patterns.py
@@ -8092,4 +8092,124 @@ PATTERNS = [
         "description": ''
     },
     # === end v0.2.31 batch ===
+
+    # === v0.2.32 batch (13 patterns, theme: retrieval_poisoning) ===
+    {
+        "id": 'GLS-RP-283',
+        "name": 'forged_source_bundle_ranking_boost_policy_exception',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:forged|fake|spoofed|tampered|fabricated)\\b)(?=.*\\b(?:source\\s+bundle|citation\\s+pack|provenance\\s+record|evidence\\s+bundle|reference\\s+manifest)\\b)(?=.*\\b(?:rank(?:ing)?\\s+boost|priority\\s+boost|top[-\\s]?rank|promote(?:d|s|ing)?|elevate(?:d|s|ing)?)\\b)(?=.*\\b(?:policy\\s+exception|policy\\s+override|guardrail\\s+bypass|trust\\s+bypass|compliance\\s+skip)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-313',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:rag|retrieval|index|knowledge\\s?base|document|context|memory)\\b)(?=.*\\b(?:seed(?:ed|ing)?|poison(?:ed|ing)?|tamper(?:ed|ing)?|inject(?:ed|ion))\\b)(?=.*\\b(?:appendix|footnote|citation|source|badge|provenance)\\b)(?=.*\\b(?:trust|verified|authoritative|official)\\b)(?=.*\\b(?:override|bypass|ignore|skip|disable)\\b)(?=.*\\b(?:policy|guardrail|review|approval|safety)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-319',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:rag|retrieval|index|knowledge[-\\s]*base|context|document|corpus|source)\\b)(?=.*\\b(?:poison(?:ed|ing)?|seed(?:ed|ing)?|inject(?:ed|ion)?|tamper(?:ed|ing)?|forg(?:ed|ery)|malicious)\\b)(?=.*\\b(?:citation|provenance|source[-\\s]*tag|reference|badge|checksum)\\b)(?=.*\\b(?:rank(?:ing)?|priority|trust|score|selection)\\b)(?=.*\\b(?:override|overrode|overriding|bypass(?:ed|ing)?|ignore(?:d|ing)?|suppress(?:ed|ing)?)\\b)(?=.*\\b(?:policy|guardrail|verification|validation)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-340',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|context|source|citation|document|passage)\\b)(?=.*\\b(?:addendum|appendix|digest|summary|errata|note)\\b)(?=.*\\b(?:forg(?:e|ed|ery)|fabricat(?:e|ed|ing)|poison(?:ed|ing)?|seed(?:ed|ing)?|tamper(?:ed|ing)?|backfill(?:ed|ing)?)\\b)(?=.*\\b(?:trust\\s+stamp|trusted\\s+source|provenance\\s+badge|credibility\\s+tag|rank\\s+signal)\\b)(?=.*\\b(?:override(?:d|s|ing)?|bypass(?:ed|es|ing)?|ignore|waive|skip(?:ped|s|ping)?)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|verification|ranking)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-327',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:rag|retrieval|index|knowledge\\s+base|context)\\b)(?=.*\\b(?:poison(?:ed|ing)?|seed(?:ed|ing)?|inject(?:ed|ion)|tamper(?:ed|ing)?)\\b)(?=.*\\b(?:provenance|citation|source\\s+tag|trust\\s+badge|digest)\\b)(?=.*\\b(?:fake|forged|fabricated|stale|spoofed)\\b)(?=.*\\b(?:override|bypass|ignore|elevat(?:e|ed|ion)|re-?rank|promote)\\b)(?=.*\\b(?:guardrail(?:s)?|policy|verification|safety\\s+check(?:s)?)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-324',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:rag|retrieval|knowledge\\s+base|context\\s+window|index)\\b)(?=.*\\b(?:poison(?:ed|ing)?|seed(?:ed|ing)?|tamper(?:ed|ing)?|inject(?:ed|ion)|staged|fabricat(?:e|ed|ion))\\b)(?=.*\\b(?:runbook|playbook|changelog|appendix|note|document)\\b)(?=.*\\b(?:provenance\\s+stamp|trusted\\s+source\\s+badge|citation\\s+badge|signed\\s+digest|verification\\s+badge)\\b)(?=.*\\b(?:rank|prioritiz(?:e|ed|ing)|promot(?:e|ed|ion)|surface|select)\\b)(?=.*\\b(?:overrid(?:e|es|ing|en|ed)?|bypass(?:ed|es|ing)?|ignore|skip(?:ped|s|ping)?|waive)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|verification|review\\s+gate(?:s)?)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-337',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retriev(?:ed|al)|source|citation|document|knowledge\\s*base|rag)\\b)(?=.*\\b(?:badge|trusted|verified|authority|rank(?:ed|ing)?|priority)\\b)(?=.*\\b(?:override|ignore|bypass|supersed(?:e|es|ed|ing)|elevat(?:e|ed|ing))\\b)(?=.*\\b(?:policy|guardrail|rule(?:s)?|safety)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-311',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:rag|retrieval|vector\\s+store|knowledge\\s+base|context\\s+cache|index)\\b)(?=.*\\b(?:seed(?:ed|ing)?|poison(?:ed|ing)?|tamper(?:ed|ing)?|inject(?:ed|ion)?|forg(?:ed|ery))\\b)(?=.*\\b(?:trust(?:ed)?|signed|checksum|provenance|citation)\\b)(?=.*\\b(?:override(?:s|n|ing)?|bypass(?:ed|es|ing)?|ignore(?:d|s|ing)?|disable(?:d|s|ing)?|skip(?:ped|s|ping)?)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|approval|validation|filter(?:s)?)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-329',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:seeded|poisoned|backfilled|injected|tampered)\\b)(?=.*\\b(?:retrieval|rag|index|corpus|knowledge\\s+base|document)\\b)(?=.*\\b(?:trust\\s+badge|provenance\\s+tag|citation\\s+badge|verified\\s+source)\\b)(?=.*\\b(?:override|bypass|ignore|prioritiz(?:e|ed|ing)|elevat(?:e|ed|ion))\\b)(?=.*\\b(?:policy|guardrail(?:s)?|rank(?:ing)?|verification|filter(?:s)?)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-317',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:rag|retrieval|knowledge[-\\s]*base|index|document|changelog|digest|appendix|source[-\\s]*note|provenance[-\\s]*badge|citation)\\b)(?=.*\\b(?:poison(?:ed|ing)?|seed(?:ed|ing)?|forg(?:ed|ery)|tamper(?:ed|ing)?|inject(?:ed|ion)|stag(?:e|ed|ing))\\b)(?=.*\\b(?:override|overrode|overriding|bypass(?:ed|ing)?|ignore(?:d|ing)?|suppress(?:ed|ing)?|disable(?:d|ing)?)\\b)(?=.*\\b(?:policy|guardrail|verification|citation[-\\s]*check|source[-\\s]*validation)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-307',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)\\b(?:retrieved|retrieval|rag|context|document|source|citation)\\b.{0,120}\\b(?:trusted|authoritative|verified|approved|high\\s+confidence|fresh(?:est)?\\s+source)\\b.{0,140}\\b(?:ignore|bypass|override|disregard|supersede|replace)\\b.{0,90}\\b(?:policy|guardrail(?:s)?|safety\\s+rule(?:s)?|instruction(?:s)?|verification\\s+gate(?:s)?)\\b'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-331',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:retrieval|rag|index|knowledge\\s*base|context|corpus)\\b)(?=.*\\b(?:poison(?:ed|ing)?|tamper(?:ed|ing)?|seed(?:ed|ing)?|backfill(?:ed|ing)?|inject(?:ed|ion))\\b)(?=.*\\b(?:citation|source|reference|provenance|digest)\\b)(?=.*\\b(?:rank(?:ing)?|score|priority|trust\\s*badge|trust)\\b)(?=.*\\b(?:override|bypass|ignore|disable)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|filter(?:s)?|boundary|verification)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RP-334',
+        "name": '(unnamed)',
+        "category": 'retrieval_poisoning',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:seeded|staged|poison(?:ed|ing)?|tampered|backfilled|forged)\\b)(?=.*\\b(?:retrieval|rag|context|citation|source|document|index|cache|digest|provenance)\\b)(?=.*\\b(?:trust\\s+badge|rank(?:ing)?|priority|authority\\s+score|confidence\\s+stamp)\\b)(?=.*\\b(?:override|bypass|manipulat(?:e|ed|ion)|elevat(?:e|ed|ion)|promot(?:e|ed|ion)|boost)\\b)(?=.*\\b(?:guardrail(?:s)?|policy|verification|safety\\s+check|approval\\s+gate)\\b).*$'],
+        "description": ''
+    },
+    # === end v0.2.32 batch ===
 ]


### PR DESCRIPTION
## Summary
- +13 GLS-RP retrieval_poisoning patterns (one-cat-per-day rule)
- 507 → 520 patterns total, keywords/categories/languages unchanged
- All Jack pre-validated 8/8 TP, 0 FP
- Pivot from v0.2.31 tool_output_poisoning category

## Status
- PyPI live: https://pypi.org/project/sunglasses/0.2.32/
- Cloudflare deploy: https://sunglasses.dev (520 patterns rendering, stat-coherence postflight PASS)
- pytest: 12/12 PASS
- preflight-check.sh: 31/31 PASS

## Test plan
- [x] python3 -m pytest (12 passed)
- [x] preflight-check.sh (31 checks)
- [x] postflight-live-render.sh (stat coherence + layout)
- [x] postflight-live-check.sh (no draft markers, all blogs reachable)