### PR TITLE
chore: simplify KNOWN_VERSION_GAPS.md

### DIFF
--- a/KNOWN_VERSION_GAPS.md
+++ b/KNOWN_VERSION_GAPS.md
@@ -1,46 +1,40 @@
-# Known Version Gaps — Sunglasses
+# Known Version Gaps
 
-This document acknowledges historical gaps in the Sunglasses release sequence on PyPI and in git tags. It exists so anyone auditing the project (security researcher, contributor, downstream user) sees a transparent record of what's missing and why.
+Quick FYI: an audit on May 6, 2026 surfaced some historical gaps in this project's version history. We fixed what was fixable and documented the rest.
 
-**Going forward (post May 6, 2026):** preflight CHECK 17 (`preflight-version-chain.sh`) blocks any new ship that would skip a patch number, and a daily integrity check (`sunglasses-integrity-check.sh`) runs at 6 AM PT to surface any new drift.
+## What we found
 
-## PyPI gaps (allowlisted)
+- 9 PyPI versions were never published (7 pre-launch + `0.2.27` and `0.2.30` which failed silent uploads)
+- 8 git tags were missing for shipped versions
 
-These versions never made it to PyPI. They are intentionally NOT being uploaded retroactively, because:
-1. `pip install sunglasses` works correctly — pulls latest, no impact on users
-2. `pip install sunglasses==X` works for any X that exists
-3. Retroactive uploads with stale code would create more confusion than they resolve
+## What we did
 
-- pypi-gap: 0.2.1 — pre-launch experimental, never published
-- pypi-gap: 0.2.2 — pre-launch experimental, never published
-- pypi-gap: 0.2.3 — pre-launch experimental, never published
-- pypi-gap: 0.2.4 — pre-launch experimental, never published
-- pypi-gap: 0.2.7 — pre-launch experimental, never published
-- pypi-gap: 0.2.8 — pre-launch experimental, never published
-- pypi-gap: 0.2.9 — pre-launch experimental, never published
-- pypi-gap: 0.2.27 — daily-push cron silently failed twine upload (post-launch); patterns shipped to git, never reached PyPI
-- pypi-gap: 0.2.30 — same root cause as 0.2.27; daily-push cron upload silently failed
+- **Tags:** all 8 missing tags were created retroactively pointing at the right commits, then pushed.
+- **PyPI gaps:** left as-is. `pip install sunglasses` works fine; retroactive uploads with stale code would create more confusion than they resolve.
 
-## Tag gaps (recovered May 6, 2026)
+## Going forward
 
-These tags were missing from git when the integrity audit ran on May 6, 2026. They were created retroactively pointing at the commit where each version's `__init__.py` was bumped, and pushed to origin.
+- Pre-flight gate blocks any new ship that would skip a patch number.
+- Daily 6 AM PT integrity check audits PyPI ↔ git tags ↔ CHANGELOG ↔ live site and surfaces drift before it builds up.
 
-Recovered: v0.2.16, v0.2.18, v0.2.22, v0.2.27, v0.2.28, v0.2.30, v0.2.31, v0.2.32, v0.2.33.
+## Allowlist (machine-readable — integrity check parses these)
 
-## Pre-launch tags (allowlisted — no recovery)
+PyPI versions accepted as not-published:
+- pypi-gap: 0.2.1
+- pypi-gap: 0.2.2
+- pypi-gap: 0.2.3
+- pypi-gap: 0.2.4
+- pypi-gap: 0.2.7
+- pypi-gap: 0.2.8
+- pypi-gap: 0.2.9
+- pypi-gap: 0.2.27
+- pypi-gap: 0.2.30
 
-These very early PyPI versions never had matching git tags and the original commits are too tangled to find clean source for. Allowlisted because they're irrelevant to current users and recovering them adds no value.
-
+Pre-launch tags accepted as not-recovered:
 - tag-gap: 0.1.0
 - tag-gap: 0.1.1
 - tag-gap: 0.2.0
 - tag-gap: 0.2.5
 - tag-gap: 0.2.6
 
-## How to add a new gap to this allowlist
-
-If a future PyPI gap is unavoidable (e.g. version yanked due to security issue):
-- Add `- pypi-gap: 0.X.Y — <reason>` to the section above
-- Re-run `bash ~/.claude/tools/sunglasses-integrity-check.sh` to confirm allowlist takes effect
-
-The integrity check reads this file and only flags NEW unallowlisted gaps. Allowlisted entries pass silently.
+To allowlist a future gap, add a `- pypi-gap: X.Y.Z` or `- tag-gap: X.Y.Z` line above and re-run the integrity check.


### PR DESCRIPTION
Tighter FYI tone. Allowlist still machine-parseable for integrity check.