### PR TITLE
v0.2.34: 543 patterns — 10 new encoded-prompt-injection bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Sunglasses are documented here.
 
+## [0.2.34] — 2026-05-07
+
+### Added
+- **10 new patterns** across the encoded-prompt-injection theme: 2 `token_smuggling` (GLS-TS-257/258), 2 `invisible_unicode` (GLS-IU-532/533), 2 `code_switching` (GLS-CS-576/577), 2 `parasitic_injection` (GLS-PI-022/023), 1 `rtl_obfuscation` (GLS-RTL-004), 1 `prompt_extraction` (GLS-PX-568). Themed bundle matched to a Cava-authored blog (JACK byline, published at `/blog/encoded-prompt-injection-runtime-trust`).
+
+
 ## [0.2.33] — 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ result = scanner.scan_auto("any_file.ext")
 |--------|-------|
 | Average text scan | <1ms (avg 0.26ms on M3 Max, single-threaded) |
 | Throughput | ~3,800 scans/sec (single-threaded, M3 Max) |
-| Patterns | 533 |
+| Patterns | 543 |
 | Keywords | 2,296 |
 | Languages | 23 |
 | Attack categories | 54 |
@@ -151,15 +151,15 @@ result = scanner.scan_auto("any_file.ext")
 | Core dependencies | Zero for text scan; optional deps for media |
 | Platforms | Mac, Windows, Linux — anywhere Python runs |
 
-_All performance numbers verified against `stats/current.json` (v0.2.33, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
+_All performance numbers verified against `stats/current.json` (v0.2.34, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
 
 ## 23 Languages
 
 English, Spanish, Portuguese, French, German, Italian, Dutch, Russian, Ukrainian, Polish, Czech, Turkish, Azerbaijani, Arabic, Hebrew, Persian, Chinese, Japanese, Korean, Hindi, Bengali, Indonesian, Vietnamese — plus normalization handles romanization, Unicode confusables, and 17 other obfuscation techniques. Community language contributions welcome.
 
-## What Works Today (v0.2.33)
+## What Works Today (v0.2.34)
 
-- ✅ Text scanning: 533 patterns, 2,296 keywords, 23 languages, 54 attack categories
+- ✅ Text scanning: 543 patterns, 2,296 keywords, 23 languages, 54 attack categories
 - ✅ Negation handling: "do NOT run rm -rf" correctly downgrades severity
 - ✅ Multi-stage pipeline: normalization (17 techniques) → pattern match → decision
 - ✅ Image scanning: OCR + EXIF metadata + hidden text detection (requires Tesseract)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sunglasses",
-    version="0.2.33",
+    version="0.2.34",
     description="Sunglasses for AI agents. Protection layer + neighborhood watch.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/stats/current.json
+++ b/stats/current.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.2.33",
-  "patterns": 533,
+  "version": "0.2.34",
+  "patterns": 543,
   "keywords": 2296,
   "categories": 54,
   "languages": 23,
@@ -16,7 +16,7 @@
   "media_types": 6,
   "reports_published": 3,
   "team_size": 5,
-  "last_updated": "2026-05-06T11:00:02.138314-07:00",
-  "last_updated_by": "daily-push-runner",
+  "last_updated": "2026-05-07T16:53:42.756476-07:00",
+  "last_updated_by": "boss-ship-v0234",
   "_note": "THIS IS THE SINGLE SOURCE OF TRUTH. All pages, JSON-LD, meta tags, llms.txt, and sitemap must read from this file. Do NOT hardcode numbers anywhere else."
 }

--- a/sunglasses/__init__.py
+++ b/sunglasses/__init__.py
@@ -4,4 +4,4 @@
 #
 # "Don't let your agents get fooled."
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"

--- a/sunglasses/patterns.py
+++ b/sunglasses/patterns.py
@@ -8332,4 +8332,95 @@ PATTERNS = [
         "description": ''
     },
     # === end v0.2.33 batch ===
+    {
+        "id": 'GLS-TS-257',
+        "name": 'hidden_yaml_policy_profile_override',
+        "category": 'token_smuggling',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:hidden|front\\s*matter|frontmatter|yaml|meta(?:data)?|comment(?:\\s*block)?|system\\s*note|annotation)\\b)(?=.*\\b(?:policy|safety|guardrail(?:s)?|profile|rule(?:s)?|instruction(?:s)?)\\b)(?=.*\\b(?:override|overrides|overriding|bypass|bypassed|ignore|ignored|waive|waived|disable|disabled|skip|skipped)\\b).+$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-IU-532',
+        "name": 'zero_width_split_override_guardrail_bypass',
+        "category": 'invisible_unicode',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*(?:i[\\u200b\\u200c\\u200d\\ufeff]*gnore|overri[\\u200b\\u200c\\u200d\\ufeff]*de|bypa[\\u200b\\u200c\\u200d\\ufeff]*ss|disregard|supersed(?:e|es|ed|ing)))(?=.*(?:policy|guardrail(?:s)?|safety\\s+rule(?:s)?|approval\\s+check(?:s)?|instruction(?:s)?))(?=.*(?:zero[\\s-]*width|zwj|zwnj|invisible\\s+unicode|u\\+200b|u\\+200c|u\\+200d)).{0,900}$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-IU-533',
+        "name": 'zero_width_split_override_chain',
+        "category": 'invisible_unicode',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)(?=.*(?:\\u200b|\\u200c|\\u200d|\\ufeff|&#8203;|&#8204;|&#8205;|&#xfeff;|\\\\u200[bcd]|\\\\ufeff))(?=.*(?:\\bi[\\u200b\\u200c\\u200d\\ufeff]*gnore(?:d|ing)?\\b|\\boverri[\\u200b\\u200c\\u200d\\ufeff]*de(?:s|d|ing)?\\b|\\boverrid(?:e|es|ing|den)\\b|\\bbypass(?:ed|ing)?\\b|\\bdisregard(?:ed|ing|s)?\\b))(?=.*\\b(?:previous|prior|system|safety|policy|guardrail(?:s)?|instruction(?:s)?)\\b).{0,600}'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-CS-576',
+        "name": 'multilingual_connector_override_guardrail_bypass',
+        "category": 'code_switching',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:ignore|ignored|ignoring|disregard(?:ed|ing|s)?|override(?:d|ing|s)?|bypass(?:ed|ing|es)?|skip(?:ped|ping|s)?)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety\\s+check(?:s)?|instruction(?:s)?|rule(?:s)?|approval\\s+gate(?:s)?|verification)\\b)(?=.*(?:\\b(?:pero|mais|cependant|aber|sin\\s+embargo|maintenant|ahora)\\b|忽略|無視|跳过|繞過|绕过|обойти|игнорируй|تجاهل|تجاوز|لكن|しかし)).+'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-CS-577',
+        "name": 'multilingual_override_guardrail_bypass',
+        "category": 'code_switching',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)(?:\\b(?:ignora|omite|desobedece|ignorer|contourner|ignoriere|umgehe|игнорируй|تجاهل)\\b|忽略|無視).{0,90}\\b(?:instructions?|instrucciones?|reglas?|policy|pol[ií]tica|guardrails?)\\b'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-PI-022',
+        "name": 'hidden_footer_instruction_execution_scope_override',
+        "category": 'parasitic_injection',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:footer|html\\s+comment|metadata|hidden\\s+note|annotation|invisible\\s+block)\\b)(?=.*\\b(?:instruction|directive|command|runbook|playbook)\\b)(?=.*\\b(?:execute|run|trigger|invoke|perform)\\b)(?=.*\\b(?:ignore|bypass|override|supersed(?:e|es|ed|ing)|disregard)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety|approval|authorization)\\b).*'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-TS-258',
+        "name": 'hidden_debug_payload_policy_waiver',
+        "category": 'token_smuggling',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:hidden|invisible|base64|frontmatter|metadata|comment)\\b)(?=.*\\b(?:debug payload|diagnostic payload|maintenance command|backdoor instruction|secret directive)\\b)(?=.*\\b(?:policy waiver|bypass policy|ignore guardrail|override safety|skip approval)\\b).*$'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-RTL-004',
+        "name": 'bidi_masked_override_directive',
+        "category": 'rtl_obfuscation',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*(?:\\u202E|\\u202D|\\u202A|\\u2066|\\u2067|\\u2068|\\u2069|U\\+[0-9A-Fa-f]{4}|right-to-left\\s+override|bidi|\\brtl\\b|rtl\\s*mark))(?=.*\\b(?:hidden|mask(?:ed|ing)?|obfuscat(?:e|ed|ing|ion)|reorder(?:ed|ing)?|visual(?:ly)?)\\b)(?=.*\\b(?:ignor(?:e|es|ing)|bypass|override|supersed(?:e|es|ed|ing)|disregard)\\b)(?=.*\\b(?:policy|guardrail(?:s)?|safety|approval|authorization)\\b).*'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-PX-568',
+        "name": 'system_prompt_recovery_override',
+        "category": 'prompt_extraction',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)(?:\\b(?:reveal|show|print|dump|expose|leak|output|return|display)\\b.{0,90}\\b(?:system\\s*prompt|hidden\\s*(?:prompt|instructions?)|developer\\s*(?:message|instructions?)|internal\\s*(?:policy|rules?))\\b|\\b(?:tell\\s+me|what\\s+is|recite|quote)\\b.{0,90}\\b(?:your|the)\\b.{0,40}\\b(?:system\\s*prompt|hidden\\s*instructions?|developer\\s*instructions?|internal\\s*policy)\\b)'],
+        "description": ''
+    },
+    {
+        "id": 'GLS-PI-023',
+        "name": 'hidden_annotation_payload_policy_override',
+        "category": 'parasitic_injection',
+        "severity": 'high',
+        "channel": ['tool_output', 'message'],
+        "regex": ['(?is)^(?=.*\\b(?:hidden|embedded|invisible|stealth|annotation|footnote|comment|metadata)\\b)(?=.*\\b(?:instruction|prompt|directive|payload)\\b)(?=.*\\b(?:ignore|bypass|override|disregard|supersed(?:e|es|ed|ing))\\b)(?=.*\\b(?:policy|guardrail|safety|rule(?:s)?)\\b).*$'],
+        "description": ''
+    },
+    # === end v0.2.34 batch (10 patterns) ===
 ]


### PR DESCRIPTION
## Summary
- 10 new detection patterns matched to today's encoded-prompt-injection theme blog (JACK byline)
- 533 → 543 patterns, 54 categories unchanged, 2,296 keywords unchanged
- Pattern IDs: GLS-TS-257/258, GLS-IU-532/533, GLS-CS-576/577, GLS-PI-022/023, GLS-RTL-004, GLS-PX-568

## Status
- PyPI: https://pypi.org/project/sunglasses/0.2.34/ (live)
- Cloudflare Pages: https://sunglasses.dev/ (live, v0.2.34 reading on stat spans)
- Blog: https://sunglasses.dev/blog/encoded-prompt-injection-runtime-trust (HTTP 200, 54.7KB)

## Test plan
- [x] pytest 12/12 PASS (test_pattern_integrity + test_sarif + test_customer_zero)
- [x] All 543 IDs unique (no collisions)
- [x] Preflight 33/33 PASS
- [x] Postflight live-check + live-render PASS (stat coherence + no overflow + new blog linked)