### PR TITLE
chore: fix v0.2.52 released-date stamp + tooling self-heal

### DIFF
--- a/stats/current.json
+++ b/stats/current.json
@@ -19,5 +19,5 @@
   "last_updated": "2026-05-27T17:39:50.003718-07:00",
   "last_updated_by": "sunglasses-publish-sh-manual-resume",
   "_note": "THIS IS THE SINGLE SOURCE OF TRUTH. All pages, JSON-LD, meta tags, llms.txt, and sitemap must read from this file. Do NOT hardcode numbers anywhere else.",
-  "released": "2026-05-26"
+  "released": "2026-05-27"
 }


### PR DESCRIPTION
## Why

AZ caught this evening (May 27 ~6 PM PT): live website showed `released: 2026-05-26` all day after v0.2.52 actually shipped on 2026-05-27.

## Root cause

`stats/current.json` is the truth source for all live stat surfaces (version.json, llms-full.txt, JSON-LD). The v0.2.52 ship took the "manual resume" path (after the dogfood incident interrupted the standard pipeline). That path bumped `version` / `patterns` / `keywords` / `categories` / `last_updated` but **never set `released`**. So `released` inherited v0.2.51's date and stats-sync propagated the stale value downstream.

## Fix

- `stats/current.json` released → `2026-05-27` (this commit)
- Paired tooling fixes in `~/.claude/tools/` (local Boss brain, not in this repo):
  - `sunglasses-publish.sh` now sets `data["released"] = TODAY` in the Step 5a Python block
  - `stats-sync.py` adds `heal_truth_released()` as Step 0 — auto-detects + patches `released` if it drifts from `last_updated` date, so manual-resume ships self-heal next time
- Website-side fix lands in the parallel landing-repo PR

## Permanent defense (not in this PR, blocked by token scope)

Pattern-integrity CI workflow staged at `/tmp/pattern-integrity.yml.staged-for-az` would have prevented the v0.2.51 dup-ID incident at PR time. Push blocked by missing `workflow` scope on the current GH token. AZ to grant + I'll resubmit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)