### PR TITLE
v0.2.55 — structured_metadata_poisoning (V2 first ship, +17 patterns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to Sunglasses are documented here.
 
 
+## [0.2.55] — 2026-05-31
+
+### Added (V2 FIRST SHIP — structured_metadata_poisoning)
+
+- **17 new patterns in the `structured_metadata_poisoning` category** — `GLS-SMP-001` through `GLS-SMP-017` (first V2 ship). New category covering attack classes that exploit structured metadata surfaces: LLM-readable manifest fields, API spec descriptions, YAML/TOML config comments, CI pipeline annotations, container labels, and package metadata files. Pattern count: 873 → **890**. Category count: 55 → **56**. Keywords: 5,726 (unchanged).
+- **New blog:** [Structured Metadata Poisoning](https://sunglasses.dev/blog/structured-metadata-poisoning) — how attackers inject instructions into structured fields that LLMs read as trusted context. Written by JACK, research by Cava.
+
+### Context
+
+- First V2 ship. V1 was fully drained in v0.2.54. V2 pool contains 146 patterns staged and isolated since May 21.
+
 ## [0.2.54] — 2026-05-30
 
 ### Added (V1 tail roundup — V1 FINISH)

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ result = scanner.scan_auto("any_file.ext")
 |--------|-------|
 | Average text scan | <1ms (avg 0.26ms on M3 Max, single-threaded) |
 | Throughput | ~3,800 scans/sec (single-threaded, M3 Max) |
-| Patterns | 873 |
+| Patterns | 890 |
 | Keywords | 5,726 |
 | Languages | 23 |
-| Attack categories | 55 |
+| Attack categories | 56 |
 | Normalization techniques | 17 |
 | Media types | 6 (text, image, audio, video, PDF, QR) |
 | Internal recall (attack-db fixture set) | 64/64 — 100% recall |
@@ -151,15 +151,15 @@ result = scanner.scan_auto("any_file.ext")
 | Core dependencies | Zero for text scan; optional deps for media |
 | Platforms | Mac, Windows, Linux — anywhere Python runs |
 
-_All performance numbers verified against `stats/current.json` (v0.2.54, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
+_All performance numbers verified against `stats/current.json` (v0.2.55, updated Apr 22, 2026). Measured on Apple M3 Max, 48GB RAM, single-threaded Python 3.11. Your hardware will differ._
 
 ## 23 Languages
 
 English, Spanish, Portuguese, French, German, Italian, Dutch, Russian, Ukrainian, Polish, Czech, Turkish, Azerbaijani, Arabic, Hebrew, Persian, Chinese, Japanese, Korean, Hindi, Bengali, Indonesian, Vietnamese — plus normalization handles romanization, Unicode confusables, and 17 other obfuscation techniques. Community language contributions welcome.
 
-## What Works Today (v0.2.54)
+## What Works Today (v0.2.55)
 
-- ✅ Text scanning: 873 patterns, 5,726 keywords, 23 languages, 55 attack categories
+- ✅ Text scanning: 890 patterns, 5,726 keywords, 23 languages, 56 attack categories
 - ✅ Negation handling: "do NOT run rm -rf" correctly downgrades severity
 - ✅ Multi-stage pipeline: normalization (17 techniques) → pattern match → decision
 - ✅ Image scanning: OCR + EXIF metadata + hidden text detection (requires Tesseract)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sunglasses",
-    version="0.2.54",
+    version="0.2.55",
     description="Sunglasses for AI agents. Protection layer + neighborhood watch.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/stats/current.json
+++ b/stats/current.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.2.54",
-  "patterns": 873,
+  "version": "0.2.55",
+  "patterns": 890,
   "keywords": 5726,
-  "categories": 55,
+  "categories": 56,
   "languages": 23,
   "normalization_techniques": 17,
   "scan_speed_avg_ms": 0.261,
@@ -16,8 +16,8 @@
   "media_types": 6,
   "reports_published": 3,
   "team_size": 5,
-  "last_updated": "2026-05-30T07:25:28-07:00",
-  "last_updated_by": "ship-v0254-direct",
+  "last_updated": "2026-05-31T03:44:00-07:00",
+  "last_updated_by": "ship-v0255",
   "_note": "THIS IS THE SINGLE SOURCE OF TRUTH. All pages, JSON-LD, meta tags, llms.txt, and sitemap must read from this file. Do NOT hardcode numbers anywhere else.",
-  "released": "2026-05-30"
+  "released": "2026-05-31"
 }

--- a/sunglasses/__init__.py
+++ b/sunglasses/__init__.py
@@ -4,4 +4,4 @@
 #
 # "Don't let your agents get fooled."
 
-__version__ = "0.2.54"
+__version__ = "0.2.55"

--- a/sunglasses/patterns.py
+++ b/sunglasses/patterns.py
@@ -16414,4 +16414,141 @@ PATTERNS = [
         ],
         "description": "Attacker seeds the agent's local reference corpus with older permissive templates, weakened fixtures, or shadow-tree mirrors, then nudges retrieval to prefer the downgraded copy over current hardened guidance. No jailbreak prompt is needed because the agent silently imports stale 'trusted' policy and regresses to weaker behavior."
     },
+    # === v0.2.55 batch (17 patterns) ===
+    {
+        "id": "GLS-SMP-001",
+        "name": "HTML Meta Agent Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "Target-controlled HTML `<meta>` / OpenGraph / Twitter Card description fields can smuggle agent-directed policy, secret-forwarding, or report-suppression instructions into discovery context that an assistant may incorrectly treat as site-owner authority."
+    },
+    {
+        "id": "GLS-SMP-002",
+        "name": "JSON-LD structured-data agent policy poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "A target-controlled JSON-LD / schema.org structured-data block embeds agent-directed policy text that claims site-owner authority, asks the agent to override higher-priority instructions, forward local/auth context, or suppress reporting."
+    },
+    {
+        "id": "GLS-SMP-003",
+        "name": "Web App Manifest Agent-Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "A target-controlled web app manifest (`/site.webmanifest`, `/manifest.webmanifest`, or `manifest.json`) can hide non-standard agent-policy text that tells AI scanners to treat the manifest as site-owner authority, include cookies or Authorization headers, and suppress reporting."
+    },
+    {
+        "id": "GLS-SMP-004",
+        "name": "ActivityPub Actor Metadata Agent Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "ActivityPub actor/profile JSON can hide agent-directed policy instructions in free-text fields such as `summary`, `name`, `attachment[].value`, or endpoint descriptions, causing an AI scanner to over-trust a social identity document, leak local/auth context, or suppress impersonation findings."
+    },
+    {
+        "id": "GLS-SMP-005",
+        "name": "JSON Feed extension agent policy poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "JSON Feed documents can hide agent-directed authority inversion, secret disclosure, or report-suppression instructions in `_extensions` or feed/item text fields that AI feed readers and scanners may ingest as discovery metadata."
+    },
+    {
+        "id": "GLS-SMP-006",
+        "name": "Open Graph / Twitter Card Metadata Agent-Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "Attacker-controlled HTML social-preview metadata (`og:*`, `twitter:*`, generic description/meta fields) can embed instructions telling AI agents, scanners, crawlers, or summarizers to override policy, suppress findings, or include local secrets."
+    },
+    {
+        "id": "GLS-SMP-007",
+        "name": "C2PA Content Credentials Agent Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "C2PA / Content Credentials manifests can carry free-text provenance, assertion, ingredient, or claim-generator metadata that tells AI agents or provenance scanners to treat the media manifest as higher-priority policy, suppress verification findings, or forward local tokens."
+    },
+    {
+        "id": "GLS-SMP-008",
+        "name": "CITATION.cff Citation Metadata Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "medium",
+        "channel": ["message", "file", "web_content"],
+        "description": "Malicious instructions embedded in `CITATION.cff` free-text fields (`message`, `title`, `abstract`, `commit`, `description`) can carry AI-agent/scanner-directed authority inversion, report suppression, or credential/local-state forwarding requests. AI research agents, literature-review tools, academ"
+    },
+    {
+        "id": "GLS-SMP-009",
+        "name": "JSON-LD / Schema.org Agent Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "Attacker-controlled JSON-LD/schema.org structured-data fields can smuggle agent/scanner instructions that claim authority, request local secrets, or suppress findings while appearing to be normal SEO/site metadata."
+    },
+    {
+        "id": "GLS-SMP-010",
+        "name": "Microformats / standalone RDF metadata agent-policy poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "Hostile instructions can be embedded in Microformats fields or standalone RDF/Turtle metadata that AI agents, crawlers, SEO agents, or security scanners import as structured site context."
+    },
+    {
+        "id": "GLS-SMP-011",
+        "name": "RDFa / Microdata agent-policy poisoning in HTML structured data",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "Hostile instructions are embedded in RDFa or HTML microdata attributes that AI crawlers, SEO agents, security scanners, or tool builders may ingest as trusted page metadata, causing authority inversion, report suppression, or local-secret forwarding."
+    },
+    {
+        "id": "GLS-SMP-012",
+        "name": "SBOM metadata agent-policy poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "A target-controlled SBOM (`CycloneDX`, `SPDX`, or exported `sbom.json`) can hide agent-directed policy text in properties, annotations, or comments that tells AI dependency scanners to treat the SBOM as higher-priority release authority, suppress findings, or forward local auth context."
+    },
+    {
+        "id": "GLS-SMP-013",
+        "name": "Source map metadata agent-policy poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "JavaScript source maps can embed agent-directed instructions in `sourcesContent`, comments, or extension fields that tell AI scanners/code assistants to override policy, suppress findings, or include local secrets in reports."
+    },
+    {
+        "id": "GLS-SMP-014",
+        "name": "Linked icon / SVG sidecar metadata agent policy poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "medium",
+        "channel": ["message", "file", "web_content"],
+        "description": "Detects hostile agent/scanner instructions hidden in linked icon or SVG sidecar metadata (`<title>`, `<desc>`, `<metadata>`, comments, or generated icon notes) that try to make AI crawlers or security scanners treat decorative assets as policy, hide findings, or forward local secrets."
+    },
+    {
+        "id": "GLS-SMP-015",
+        "name": "WebAssembly Custom-Section Agent Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "WebAssembly module metadata or custom-section text can carry agent-targeted instructions that claim authority over code-security agents, suppress findings, or request local CI/env secrets while looking like ordinary build/provenance metadata."
+    },
+    {
+        "id": "GLS-SMP-016",
+        "name": "CodeMeta / DataCite / RO-Crate Metadata Agent Policy Poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "Machine-readable scholarly/software dataset metadata (`codemeta.json`, DataCite exports, and RO-Crate JSON-LD) can carry agent-facing instructions that falsely claim authority over AI research, provenance, or dependency scanners and direct them to suppress findings or forward local/runtime secrets."
+    },
+    {
+        "id": "GLS-SMP-017",
+        "name": "IaC stack template metadata poisoning",
+        "category": "structured_metadata_poisoning",
+        "severity": "high",
+        "channel": ["message", "file", "web_content"],
+        "description": "IaC stack/template metadata fields can smuggle agent-facing policy instructions that tell AI DevOps, cloud-security, or deployment-review agents to treat attacker-controlled descriptions as authoritative, suppress drift/security findings, or forward cloud credentials and local runtime context."
+    },
 ]


### PR DESCRIPTION
## Summary
- +17 new patterns GLS-SMP-001..017 in new category \`structured_metadata_poisoning\` (first V2 pool ship)
- Covers: HTML meta/OG, JSON-LD/schema.org, web manifests, ActivityPub, JSON Feed, C2PA, CITATION.cff, Microformats/RDF, RDFa/microdata, SBOM (CycloneDX/SPDX), source maps, SVG sidecar, WebAssembly custom sections, CodeMeta/DataCite/RO-Crate, IaC stack templates
- Pattern count: 873 → **890**. Categories: 55 → **56**. Keywords: 5,726 (unchanged).
- CHANGELOG.md entry added for v0.2.55.

## Status
- PyPI v0.2.55 LIVE: https://pypi.org/project/sunglasses/0.2.55/
- Cloudflare deploy 40a482ed complete
- 35/35 preflights PASS
- 12/12 integrity + dogfood tests PASS

## Test plan
- [x] 35/35 preflight checks green
- [x] Pattern integrity tests (12/12 passed)
- [x] Dogfood preflight (fresh-venv, 4 checks PASS)
- [x] Pre-push hook clean